### PR TITLE
Chunks 4-5

### DIFF
--- a/types/desktop-service/index.d.ts
+++ b/types/desktop-service/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { EventEmitter } from "events";
 
 interface ServiceConfigOptions {

--- a/types/desktop-service/package.json
+++ b/types/desktop-service/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/tariibaba/desktop-service#readme"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/desktop-service": "workspace:."
     },

--- a/types/discord-rpc/package.json
+++ b/types/discord-rpc/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/discordjs/RPC#readme"
     ],
+    "dependencies": {
+        "@types/events": "*"
+    },
     "devDependencies": {
         "@types/discord-rpc": "workspace:."
     },

--- a/types/empower-core/index.d.ts
+++ b/types/empower-core/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 /**
  * Enhances Power Assert feature to assert function/object.
  *

--- a/types/empower-core/package.json
+++ b/types/empower-core/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/twada/power-assert-runtime"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/empower-core": "workspace:."
     },

--- a/types/empower/package.json
+++ b/types/empower/package.json
@@ -10,7 +10,8 @@
         "@types/power-assert-formatter": "*"
     },
     "devDependencies": {
-        "@types/empower": "workspace:."
+        "@types/empower": "workspace:.",
+        "@types/node": "*"
     },
     "contributors": [
         {

--- a/types/eris-sharder/index.d.ts
+++ b/types/eris-sharder/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import * as Eris from "eris";
 import { EventEmitter } from "events";
 

--- a/types/eris-sharder/package.json
+++ b/types/eris-sharder/package.json
@@ -6,7 +6,9 @@
         "https://github.com/discordware/eris-sharder"
     ],
     "dependencies": {
-        "eris": "^0.15.1"
+        "eris": "^0.15.1",
+        "@types/node": "*",
+        "@types/ws": "*"
     },
     "devDependencies": {
         "@types/eris-sharder": "workspace:."

--- a/types/express-multipart-file-parser/package.json
+++ b/types/express-multipart-file-parser/package.json
@@ -6,7 +6,7 @@
         "https://github.com/cristovao-trevisan/express-multipart-file-parser#readme"
     ],
     "dependencies": {
-        "@types/busboy": "^0.2.3 || ^0.3.0",
+        "@types/busboy": "^1",
         "@types/node": "*",
         "raw-body": "^2.3.2"
     },

--- a/types/fb-watchman/index.d.ts
+++ b/types/fb-watchman/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { EventEmitter } from "events";
 
 // Emit the responses to these when they get sent down to us

--- a/types/fb-watchman/package.json
+++ b/types/fb-watchman/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://facebook.github.io/watchman/"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/fb-watchman": "workspace:."
     },

--- a/types/formdata/index.d.ts
+++ b/types/formdata/index.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import { EventEmitter } from "events";
 
 declare class FormData {

--- a/types/formdata/package.json
+++ b/types/formdata/package.json
@@ -5,6 +5,9 @@
     "projects": [
         "https://github.com/node-file-api/FormData"
     ],
+    "dependencies": {
+        "@types/node": "*"
+    },
     "devDependencies": {
         "@types/formdata": "workspace:."
     },


### PR DESCRIPTION
All node or events deps except:

- eris-sharder had a transitive dep on eris, which was missing a dep on types/ws
- express-multipart-file-parser depended on an old version of types/busboy. I'm not sure why it passed before.
