### PR TITLE
Make all node deps refer to versions on DT

### DIFF
--- a/types/gsheetdb/package.json
+++ b/types/gsheetdb/package.json
@@ -6,7 +6,7 @@
         "https://github.com/zdettwiler/gsheetdb"
     ],
     "dependencies": {
-        "@types/node": "^18.0.25",
+        "@types/node": "*",
         "google-auth-library": "^7.14.1"
     },
     "devDependencies": {

--- a/types/gsheetdb/package.json
+++ b/types/gsheetdb/package.json
@@ -6,7 +6,7 @@
         "https://github.com/zdettwiler/gsheetdb"
     ],
     "dependencies": {
-        "@types/node": "^17.0.25",
+        "@types/node": "^18.0.25",
         "google-auth-library": "^7.14.1"
     },
     "devDependencies": {

--- a/types/knex-db-manager/package.json
+++ b/types/knex-db-manager/package.json
@@ -6,7 +6,7 @@
         "https://github.com/Vincit/knex-db-manager#readme"
     ],
     "dependencies": {
-        "@types/node": "^16.0.0",
+        "@types/node": "*",
         "knex": "2.1.0"
     },
     "devDependencies": {

--- a/types/knex-db-manager/package.json
+++ b/types/knex-db-manager/package.json
@@ -6,7 +6,7 @@
         "https://github.com/Vincit/knex-db-manager#readme"
     ],
     "dependencies": {
-        "@types/node": "16.0.0",
+        "@types/node": "^16.0.0",
         "knex": "2.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
This requirement doesn't seem strictly necessary, but existing DT conforms to it, and it makes deprecation PRs work, so we decided to leave it on for everything for now.